### PR TITLE
Ensure that the uploaded media has been processed before completing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # twitter-media
 
-
 Simple module for uploading media to Twitter. It can handle images, videos and image sets and returns media_ids, which can be posted with Twitter statuses.
 
 ## API
@@ -16,7 +15,7 @@ An object containing Twitter API credentials
 		token: '...',
 		token_secret: '...'
 	}
-	
+
 ### TwitterMedia#uploadMedia(type, media, callback)
 
 #### type: String
@@ -31,15 +30,10 @@ Node.js buffer containing uploaded media
 #### images: [Buffer]
 Images argument is array of buffers containing uploaded images. Twitter allows up to 4 images at one tweet.
 
-## Testing
-Simple as
-
-	npm test
-
 ## License
 The MIT License (MIT)
 
-Copyright (c) 2015 Jan Žaloudek
+Copyright (c) 2017 Jan Žaloudek
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/image-set.js
+++ b/examples/image-set.js
@@ -1,8 +1,9 @@
 var MediaUpload = require('../');
 var fs = require('fs');
 var oauthCreds = require('../config0.js');
+var path = require('path');
 
-var media = fs.readFileSync('./image.jpg');
+var media = fs.readFileSync(path.join(__dirname, 'image.jpg'));
 
 var media_upload = new MediaUpload(oauthCreds);
 media_upload.uploadImageSet([ media, media, media ], console.log);

--- a/examples/image.js
+++ b/examples/image.js
@@ -1,8 +1,9 @@
 var MediaUpload = require('../');
 var fs = require('fs');
 var oauthCreds = require('../config0.js');
+var path = require('path');
 
-var media = fs.readFileSync('./image.jpg');
+var media = fs.readFileSync(path.join(__dirname, 'image.jpg'));
 
 var media_upload = new MediaUpload(oauthCreds);
 media_upload.uploadMedia('image', media, console.log);

--- a/examples/video.js
+++ b/examples/video.js
@@ -1,8 +1,9 @@
 var MediaUpload = require('../');
 var fs = require('fs');
 var oauthCreds = require('../config0.js');
+var path = require('path');
 
-var media = fs.readFileSync('./video2.mp4');
+var media = fs.readFileSync(path.join(__dirname, 'video2.mp4'));
 
 var media_upload = new MediaUpload(oauthCreds);
 media_upload.uploadMedia('video', media, console.log);

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./src/media-upload.js');

--- a/package.json
+++ b/package.json
@@ -2,10 +2,7 @@
   "name": "twitter-media",
   "version": "0.1.0",
   "description": "Library for handling Twitter media uploads",
-  "main": "index.js",
-  "scripts": {
-    "test": "mocha"
-  },
+  "main": "src/media-upload.js",
   "keywords": [
     "twitter",
     "media",

--- a/src/media-upload.js
+++ b/src/media-upload.js
@@ -134,12 +134,9 @@ MediaUpload.prototype._splitMedia = function (media) {
 
 	var partsCount = Math.ceil(media.length / MediaUpload.CHUNK_SIZE);
 
-	// console.log('Parts count', partsCount);
-
 	for (var partNr = 0; partNr < partsCount; partNr++) {
 		var startPointer = partNr * MediaUpload.CHUNK_SIZE;
 		var endPointer = (partNr === partsCount - 1)? undefined : (partNr + 1) * MediaUpload.CHUNK_SIZE;
-		// console.log('Parts nr %d begins at %d, ends at %s', partNr, startPointer, endPointer);
 		var part = media.slice(startPointer, endPointer);
 
 		parts.push(part);
@@ -164,8 +161,6 @@ MediaUpload.prototype._appendMedia = function (media_id, media, callback) {
 			segment_index: index,
 			media: part
 		};
-
-		// console.log('Uploading segment %d of %d. Segment length %d', index, parts.length - 1, part.length);
 
 		self._postRequest({
 			url: MediaUpload.UPLOAD_ENDPOINT,
@@ -232,8 +227,6 @@ MediaUpload.prototype._ensureCompleteness = function (body, callback) {
 
 	var isComplete = !body.processing_info || ['succeeded', 'failed'].indexOf(body.processing_info.state) >= 0;
 	var hasFailed = body.processing_info && body.processing_info.state === 'failed';
-
-	// console.log('Checking status of uploaded media', body.media_id_string);
 
 	if (!isComplete) {
 		var checkStatus = function() {


### PR DESCRIPTION
It can take time for Twitter to process large multi-part video uploads, which requires us to make `STATUS` calls with the `media_id` to check on its progress before we can execute the callback.

This isn't well documented on the Twitter Developer docs (unsurprising), but there's a small inline code comment on the docs for the `FINALIZE` command: https://dev.twitter.com/rest/reference/post/media/upload-finalize