### PR TITLE
Added support for remote media streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ An object containing Twitter API credentials
 		token_secret: '...'
 	}
 
-### TwitterMedia#uploadMedia(type, media, callback)
+### TwitterMedia#uploadMedia(type, source, callback)
 
 #### type: String
 Possible values are: "image", "video"
 
-#### media: Buffer
-Node.js buffer containing uploaded media
+#### source: Buffer | String
+Node.js buffer containing uploaded media or url to fetch media from.
 
 
 ### TwitterMedia#uploadImageSet(images, callback)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test": "jest"
   },
   "dependencies": {
-    "request": "^2.57.0"
+    "request": "^2.57.0",
+    "stream-chunker": "^1.2.8"
   },
   "devDependencies": {
     "jest": "^20.0.4"

--- a/src/api-client/__mocks__/index.js
+++ b/src/api-client/__mocks__/index.js
@@ -23,12 +23,12 @@ module.exports = class MockApiClient {
         });
     }
 
-    uploadVideo(buffer) {
+    uploadVideo(sourceStream, size) {
         const id = this.getMediaID();
         return Promise.resolve({
             media_id: id,
             media_id_string: String(id),
-            size: buffer.length,
+            size: size,
             expires_after_secs: 86399,
             video: {
                 video_type: 'video/mp4'

--- a/src/api-client/buffer-to-stream.js
+++ b/src/api-client/buffer-to-stream.js
@@ -1,0 +1,8 @@
+const Duplex = require('stream').Duplex;
+
+module.exports = function (buffer) {
+    let stream = new Duplex();
+    stream.push(buffer);
+    stream.push(null);
+    return stream;
+}

--- a/src/api-client/index.js
+++ b/src/api-client/index.js
@@ -16,6 +16,7 @@ module.exports = class APIClient {
     }
 
     uploadVideo(sourceStream, size) {
+      sourceStream.pause();
       return new Promise((resolve, reject) => {
         let uploadJob
         this._initUpload(size).then((mediaID) => {
@@ -39,6 +40,7 @@ module.exports = class APIClient {
             })
 
             sourceStream.pipe(chunker(DEFAULT_CHUNK_SIZE, { flush: true })).pipe(appender)
+            sourceStream.resume();
 
         }).catch(reject)
       })

--- a/src/api-client/remote-file-size.js
+++ b/src/api-client/remote-file-size.js
@@ -1,0 +1,31 @@
+/**
+ * Inspired by https://github.com/evanlucas/remote-file-size
+ */
+
+const request = require('request')
+
+module.exports = function(uri) {
+
+  return new Promise((resolve, reject) => {
+
+    let options = { uri }
+
+    options.method = 'HEAD'
+    options.followAllRedirects = true
+    options.followOriginalHttpMethod = true
+
+    request(options, (err, res) => {
+      if (err) return reject(err)
+      const code = res.statusCode
+      if (code >= 400) {
+        return reject(new Error('Received invalid status code: ' + code))
+      }
+
+      if (!res.headers['content-length']) {
+        return reject(new Error('Unable to determine file size'))
+      }
+
+      resolve(Number(res.headers['content-length']))
+    })
+  })
+}

--- a/src/api-client/split-buffer.js
+++ b/src/api-client/split-buffer.js
@@ -1,9 +1,0 @@
-module.exports = function(buffer, chunkSize) {
-    const chunks = Math.ceil(buffer.length / chunkSize);
-
-    return new Array(chunks).fill(null).map((_, index) => {
-        const start = index * chunkSize;
-        const end = (index === chunks - 1) ? undefined : (index + 1) * chunkSize;
-        return buffer.slice(start, end);
-    });
-};


### PR DESCRIPTION
Extended uploadMedia() to accept source:String alongside with source:Buffer.

When source is an url, media is streamed from remote source to Twitter in 0.5MB chunks. This method uses less memory compared to Buffer and can be used even for large videos (supported up to 512MB, 140s).